### PR TITLE
Issue is occuring using --checkpoint-open-files for ckpting open files

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -556,6 +556,9 @@ void FileConnection::drain()
     // one after restart and if the current process wasn't the leader, it never
     // had a chance to update the _path. Update it now.
     _path = jalib::Filesystem::GetDeviceName(_fds[0]);
+    if (!jalib::Filesystem::FileExists(_path)) {
+      _type = FILE_DELETED;
+    }
   }
 
   calculateRelativePath();


### PR DESCRIPTION
Consider a scenario in which file was opened for writing and however
its got deleted in between prior to taking dmtcp checkpoint. fds are
still opened for process but file is actually deleted. This is not
handled and dmtcp checkpoint exit as it tries to checkpoint the deleted
file. This was handled in previous within handleUnlinked file function
but code was cleaned.

Note: This has been committed in master already, so porting code to
2.5 branch too
